### PR TITLE
Improvement-hyperlinks

### DIFF
--- a/github-devops-refresher/pull-requests.qmd
+++ b/github-devops-refresher/pull-requests.qmd
@@ -15,7 +15,7 @@ Now you have made changes in your [development branch](making-a-development-bran
 Once you have made all the changes you want to include in this batch of work, you'll bundle all of your commits together into a pull request for review.
 
 ::: {.callout-note}
-Before attempting to create your pull request, make sure to have pushed any changes on the branches involved to the remote repo on GitHub
+Before attempting to create your pull request, make sure to have pushed any changes on the branches involved to the remote repo on GitHub. To refresh your memory on how to save, commit and push changes, see [recording changes](../git-refresher/recording-changes.qmd) and [syncing to the remote (push)](../git-refresher/syncing-changes-to-remote.qmd).
 :::
 
 ::: panel-tabset


### PR DESCRIPTION
## Overview of changes
Adding links from the create PR page to the pages which discuss how to add and commit and push changes. 

## Why are these changes being made?
Users may not complete the academy learning in one sitting, as they may take breaks or complete this in their free time, meaning they may not fully remember how to perform these actions.

## Detailed description of changes
Added links to the callout box which currently reminds users to ensure they have committed and pushed up. 

## Issue ticket number/s and link
Issue #33 https://github.com/dfe-analytical-services/git-academy/issues/33

## Checklist before requesting a review
- [X] I have checked the contributing guidelines
- [X] I have checked for and linked any relevant issues that this may resolve
- [X] I have checked that these changes build locally
- [X] I understand that if merged into main, these changes will be publicly available
