### PR TITLE
Improvement/log reminders

### DIFF
--- a/git-refresher/making-more-branches.qmd
+++ b/git-refresher/making-more-branches.qmd
@@ -70,5 +70,5 @@ git push -u origin <github_username>/development
 
 ::: callout-caution
 ## Edit your git-academy-log file
-Now you have made your development branch, go to your git log and update tick the 'making a second branch' box, before [adding, committing and pushing the changes](recording-changes.html).
+Now you have made your development branch, go to your git log and tick the boxes under 'Making more branches', before [adding, committing and pushing the changes](recording-changes.html).
 :::

--- a/git-refresher/making-more-branches.qmd
+++ b/git-refresher/making-more-branches.qmd
@@ -70,5 +70,5 @@ git push -u origin <github_username>/development
 
 ::: callout-caution
 ## Edit your git-academy-log file
-Now you have made your development branch, go to your git log and update tick the 'making a second branch' box, before [adding, committing and pushing the changes](recording-changes).
+Now you have made your development branch, go to your git log and update tick the 'making a second branch' box, before [adding, committing and pushing the changes](recording-changes.html).
 :::

--- a/git-refresher/making-more-branches.qmd
+++ b/git-refresher/making-more-branches.qmd
@@ -68,7 +68,7 @@ git push -u origin <github_username>/development
 
 :::
 
-::: callout-caution
+::: callout-note
 ## Edit your git-academy-log file
 Now you have made your development branch, go to your git log and tick the boxes under 'Making more branches', before [adding, committing and pushing the changes](recording-changes.html).
 :::

--- a/git-refresher/making-more-branches.qmd
+++ b/git-refresher/making-more-branches.qmd
@@ -37,7 +37,7 @@ git push -u origin <github_username>/development
 
 2. In the Git panel, click the purple new branch symbol ![symbol containing two purple boxes branching from a diamond](images/new-branch_rstudio-button.png) as to the left of the username in the screenshot below.
 
-3. Then enter your development branch name as **`<github_username>/development`** (but replacing <github_id> with your own GitHub username, e.g. `jsmith/development`)
+3. Then enter your development branch name as **`<github_username>/development`** (but replacing <github_username> with your own GitHub username, e.g. `jsmith/development`)
 
 ![Creating a new branch in RStudio](./images/dev_branch_RStudio.png)
 

--- a/git-refresher/moving-between-branches.qmd
+++ b/git-refresher/moving-between-branches.qmd
@@ -81,6 +81,9 @@ You can also use the `git switch` command interchangeably with the git checkout 
       
 -   Check the "git-academy-log.md" file and you'll see your edits have returned.
 
+:::
 
-
+::: callout-note
+## Edit your git-academy-log file
+Now you have moved between branches, go to your git log and tick the boxes under 'Moving between branches' before [adding, committing and pushing the changes](recording-changes.html).
 :::

--- a/git-refresher/recording-changes.qmd
+++ b/git-refresher/recording-changes.qmd
@@ -11,6 +11,8 @@ Having [created your own branch](making-a-branch.html), you should now record th
 ::: callout-caution
 ## Edit your git-academy-log file
 
+-   Open your `git-academy-log.md` file. You can do this either in the file explorer pane of the software you are using, or by double clicking on the file in the folder you have saved it in locally. 
+
 -   Put an x inside the brackets for the "Clone git-academy-sandbox" and "Create a new branch in GitHub (\<github_username\>/main)".
 
 -   Save the file.

--- a/git-refresher/recording-changes.qmd
+++ b/git-refresher/recording-changes.qmd
@@ -13,7 +13,7 @@ Having [created your own branch](making-a-branch.html), you should now record th
 
 -   Open your `git-academy-log.md` file. You can do this either in the file explorer pane of the software you are using, or by double clicking on the file in the folder you have saved it in locally. 
 
--   Put an x inside the brackets for the "Clone git-academy-sandbox" and "Create a new branch in GitHub (\<github_username\>/main)".
+-   Put an x inside the brackets for the "Clone git-academy-sandbox" and "Create a new branch (\<github_username\>/main)".
 
 -   Save the file.
 :::

--- a/git-refresher/recording-changes.qmd
+++ b/git-refresher/recording-changes.qmd
@@ -6,7 +6,7 @@ This section will guide you through recording changes you make to your repo thro
 
 These steps help you manage and track changes in your project, making collaboration and version control efficient and reliable.
 
-Having [created your own branch](making-a-branch.html), follow the instructions below to make and record changes in your repo.
+Having [created your own branch](making-a-branch.html), you should now record this change in the logbook provided in the git-academy-sandbox repository. This will mean you have recorded your progress so far, and made a change to a file which you can then practice recording. Follow the instructions below to make and record changes in your repo.
 
 ::: callout-caution
 ## Edit your git-academy-log file

--- a/git-refresher/syncing-changes-to-remote.qmd
+++ b/git-refresher/syncing-changes-to-remote.qmd
@@ -53,3 +53,8 @@ Alternatively you can push and commit your changes at the same time from the com
 
 ![](images/pycharm_push2.png){fig-alt="Highlighting the Commit and Push button in the Commit pop up window that appears after following the steps in recoding changes part of this guide." fig-width="80%" fig-align="center"}
 :::
+
+
+:::: callout-note
+Remember to fill in your logbook now that you have completed these steps. You should open the file and tick off the tasks you have completed, and then before [adding, committing and pushing the changes](recording-changes.html). 
+::::

--- a/git-refresher/syncing-changes-to-remote.qmd
+++ b/git-refresher/syncing-changes-to-remote.qmd
@@ -56,5 +56,5 @@ Alternatively you can push and commit your changes at the same time from the com
 
 
 :::: callout-note
-Remember to fill in your logbook now that you have completed these steps. You should open the file and tick off the tasks you have completed, and then before [adding, committing and pushing the changes](recording-changes.html). 
+Remember to fill in your logbook now that you have completed these steps. You should open the file and tick off the tasks you have completed under the header "Recording changes (add and commit)" and "Syncing to the remote (push), before then [adding, committing and pushing the changes](recording-changes.html). 
 ::::

--- a/github-devops-refresher/navigating-branches.qmd
+++ b/github-devops-refresher/navigating-branches.qmd
@@ -19,5 +19,5 @@ To view and switch between the different branches available in a GitHub reposito
 
 ::: callout-note
 ## Edit your git-academy-log file
-Now you have practiced navigating branches, ensure you are on your <github_username>/main branch, go to your git log and tick the boxes under 'Navigating branches', before [adding, committing and pushing the changes](recording-changes.html).
+Now you have practiced navigating branches, ensure you are on your `<github_usernname>/main` branch, go to your git log and tick the boxes under 'Navigating branches', before [adding, committing and pushing the changes](recording-changes.html).
 :::

--- a/github-devops-refresher/navigating-branches.qmd
+++ b/github-devops-refresher/navigating-branches.qmd
@@ -2,6 +2,11 @@
 title: "Navigating branches"
 ---
 
+::: {.callout-note}
+## Default Branch
+The default branch is like the main version of your project. It's usually called main, but sometimes it might have a different name. This is the branch where the latest, most stable version of your project lives. When you want to make changes to code, you usually create your own branch from main. 
+:::
+
 To view and switch between the different branches available in a GitHub repository, follow these steps:
 
 1.  Navigate to the repository on GitHub. In this case, [Git-academy-sandbox](https://github.com/dfe-analytical-services/git-academy-sandbox){target="_blank"}.
@@ -12,7 +17,7 @@ To view and switch between the different branches available in a GitHub reposito
 
 3. A list of all of the branches in the repository which have been synced to the remote will be shown. You can select any branch to view its contents. You can search branches using the search box or just see your own, active or stale branches by moving through the tabs. 
 
-::: {.callout-note}
-## Default Branch
-The default branch is like the main version of your project. It's usually called main, but sometimes it might have a different name. This is the branch where the latest, most stable version of your project lives. When you want to make changes to code, you usually create your own branch from main. 
+::: callout-note
+## Edit your git-academy-log file
+Now you have navigated branches, go to your git log and tick the boxes under 'Navigating branches', before [adding, committing and pushing the changes](recording-changes.html).
 :::

--- a/github-devops-refresher/navigating-branches.qmd
+++ b/github-devops-refresher/navigating-branches.qmd
@@ -19,5 +19,5 @@ To view and switch between the different branches available in a GitHub reposito
 
 ::: callout-note
 ## Edit your git-academy-log file
-Now you have navigated branches, go to your git log and tick the boxes under 'Navigating branches', before [adding, committing and pushing the changes](recording-changes.html).
+Now you have practiced navigating branches, ensure you are on your <github_username>/main branch, go to your git log and tick the boxes under 'Navigating branches', before [adding, committing and pushing the changes](recording-changes.html).
 :::

--- a/github-devops-refresher/pull-requests.qmd
+++ b/github-devops-refresher/pull-requests.qmd
@@ -24,7 +24,7 @@ Before attempting to create your pull request, make sure to have pushed any chan
 Create your pull request, adding a title and a description of your changes 
 
 ``` bash
-gh pr create --base <github_id>/main --head <github_id>/development --title "Update to log book" --body "Updating logbook to reflect completing the development branch task."
+gh pr create --base <github_id>/main --head <github_username>/development --title "Update to log book" --body "Updating logbook to reflect completing the development branch task."
 ```
 
 ## GitHub Website

--- a/github-devops-refresher/viewing-files.qmd
+++ b/github-devops-refresher/viewing-files.qmd
@@ -10,7 +10,7 @@ To view a file on your repo:
 
 ![](images/repo_code_tab.png){fig-alt="Screenshot of the git-academy-sandbox repository on GitHub, highlighting the 'Code' tab."}
 
-3. Find and select the branch you previously created i.e. `<github_id>/main`. You can do this by clicking on the branches button and selecting your branch, or using the branch drop-down as below to click on your branch: 
+3. Find and select the branch you previously created i.e. `<github_username>/main`. You can do this by clicking on the branches button and selecting your branch, or using the branch drop-down as below to click on your branch: 
 
 
 ![](images/viewing_branches_drop_down.png){fig-alt="Screenshot of the git-academy-sandbox repository on GitHub, displaying the branches drop-down menu with 'main' selected."}

--- a/github-devops-refresher/viewing-history.qmd
+++ b/github-devops-refresher/viewing-history.qmd
@@ -4,7 +4,7 @@ title: "Viewing the history"
 
 1.  Ensure you are still on the GitHub site for the github-sandbox repository. 
 
-2.  Select the branch you would like to see history for from the 'Branch' drop down menu, in this case, the `<github_id>/main` branch you created. 
+2.  Select the branch you would like to see history for from the 'Branch' drop down menu, in this case, the `<github_username>/main` branch you created. 
 
 ![](images/viewing_branches_drop_down.png){fig-alt="Image shows a screengrab of the git-academy-sandbox repository, with the branches drop-down selected"}
 

--- a/index.qmd
+++ b/index.qmd
@@ -21,7 +21,7 @@ repository where you can practice using Git in a contained environment.
 You can follow through tasks in order or in some cases jump in at specific points 
 where you feel you need to target your learning. A logbook is provided within the 
 [git-academy-sandbox](https://github.com/dfe-analytical-services/git-academy-sandbox)
-repo. The logbook is alongside this guide to record your progress and practice 
+repo. The logbook is to be used alongside this guide to record your progress and practice 
 making and recording changes.
 
 :::: {.callout-note}

--- a/index.qmd
+++ b/index.qmd
@@ -16,10 +16,13 @@ Welcome to the DfE's Git Academy. This is a collection of interactive tasks you
 can work through to help learn and practice using Git. As this is intended to be
 a practical guide, we provide the 
 [git-academy-sandbox](https://github.com/dfe-analytical-services/git-academy-sandbox) 
-repository where you can practice using Git in a contained environment.
+repository where you can practice using Git in a contained environment. 
 
 You can follow through tasks in order or in some cases jump in at specific points 
-where you feel you need to target your learning.
+where you feel you need to target your learning. A logbook is provided within the 
+[git-academy-sandbox](https://github.com/dfe-analytical-services/git-academy-sandbox)
+repo. The logbook is alongside this guide to record your progress and practice 
+making and recording changes.
 
 :::: {.callout-note}
 This isn't aimed at being a comprehensive reference guide. If you need more extensive


### PR DESCRIPTION
## Overview of changes

## Why are these changes being made?

To make it more clear to the user what the git-academy-sandbox log is and to remind the user more frequently to update it, so they can continue to practice saving, committing and pushing to the remote

## Detailed description of changes
- Adding a little bit of info on the log into the intro 
- Adding more frequent reminders for the user to update their log
- Added clearer instructions in 'recording changes' 
- Fixed broken link 

## Issue ticket number/s and link
#36 
#40 

## Note

The sandbox log needs updating further to match the git-devops-refresher titles. It also has a heading 'Viewing the history locally' which I don't think is currently being used. 

## Checklist before requesting a review
- [X] I have checked the contributing guidelines
- [X] I have checked for and linked any relevant issues that this may resolve
- [X] I have checked that these changes build locally
- [X] I understand that if merged into main, these changes will be publicly available
